### PR TITLE
Fix point coordinates in SAM plugin

### DIFF
--- a/plugins/bioimageio-colab-sam.imjoy.html
+++ b/plugins/bioimageio-colab-sam.imjoy.html
@@ -690,7 +690,8 @@ class BioImageIOColabSAM {
                         console.log("add point at", shape.geometry.coordinates)
                         if(!this.predictor_id)
                             this.predictor_id = await this.biocolab.compute_embeddings("vit_b", null, false)
-                        const point_coords = [shape.geometry.coordinates]//[[100, 120]]
+                        // The point coordinates need to be reversed to match the coordinate convention of SAM.
+                        const point_coords = [shape.geometry.coordinates.reverse()]
                         
                         const point_labels = []
                         for(let coord of point_coords){


### PR DESCRIPTION
Reversing the order fixes the point prompts for SAM:


https://github.com/bioimage-io/bioimageio-colab/assets/4263537/70a493f4-5721-4d54-a80d-825d70b9a1f3

