### PR TITLE
Improved sam deployment

### DIFF
--- a/bioimageio_colab/__main__.py
+++ b/bioimageio_colab/__main__.py
@@ -27,19 +27,25 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--cache_dir",
-        default="./.model_cache",
+        default="/tmp/ray/.model_cache",
         help="Directory for caching the models",
-    )
-    parser.add_argument(
-        "--model_names",
-        nargs="+",
-        default=["sam_vit_b", "sam_vit_b_lm", "sam_vit_b_em_organelles"],
-        help="List of SAM model names to deploy",
     )
     parser.add_argument(
         "--ray_address",
         default=None,
         help="Address of the Ray cluster for running SAM",
+    )
+    parser.add_argument(
+        "--skip_test_runs",
+        default=False,
+        action="store_true",
+        help="Skip test run of each model",
+    )
+    parser.add_argument(
+        "--require_login",
+        default=False,
+        action="store_true",
+        help="Require login to access the function `compute_image_embedding`",
     )
     args = parser.parse_args()
 

--- a/bioimageio_colab/models/__init__.py
+++ b/bioimageio_colab/models/__init__.py
@@ -1,1 +1,1 @@
-from .sam_image_encoder import sam_app_registry
+from .sam_deployment import SamDeployment, SAM_MODELS

--- a/bioimageio_colab/models/sam_deployment.py
+++ b/bioimageio_colab/models/sam_deployment.py
@@ -1,0 +1,62 @@
+import os
+
+import aiohttp
+import numpy as np
+from ray import serve
+
+from .sam_image_encoder import SamImageEncoder
+
+SAM_MODELS = {
+    "sam_vit_b": {
+        "architecture": "vit_b",
+        "url": "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_b_01ec64.pth",
+    },
+    "sam_vit_b_lm": {
+        "architecture": "vit_b",
+        "url": "https://uk1s3.embassy.ebi.ac.uk/public-datasets/bioimage.io/diplomatic-bug/1/files/vit_b.pt",
+    },
+    "sam_vit_b_em_organelles": {
+        "architecture": "vit_b",
+        "url": "https://uk1s3.embassy.ebi.ac.uk/public-datasets/bioimage.io/noisy-ox/1/files/vit_b.pt",
+    },
+}
+
+
+# Default deployment options can be overridden by `deployment.options()`
+@serve.deployment(
+    ray_actor_options={"num_gpus": 1},
+    max_ongoing_requests=1,
+)
+class SamDeployment:
+    def __init__(self, cache_dir: str):
+        self.cache_dir = cache_dir
+        self.models = SAM_MODELS
+
+    async def _download_model(self, model_path: str, model_url: str) -> None:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(model_url) as response:
+                if response.status != 200:
+                    raise RuntimeError(f"Failed to download model from {model_url}")
+                content = await response.read()
+                with open(model_path, "wb") as f:
+                    f.write(content)
+
+    @serve.multiplexed(max_num_models_per_replica=2)
+    async def get_model(self, model_id: str):
+        model_path = os.path.join(self.cache_dir, f"{model_id}.pt")
+
+        if not os.path.exists(model_path):
+            os.makedirs(self.cache_dir, exist_ok=True)
+            await self._download_model(
+                model_path=model_path,
+                model_url=self.models[model_id]["url"],
+            )
+
+        return SamImageEncoder(
+            model_path=model_path,
+            model_architecture=self.models[model_id]["architecture"],
+        )
+
+    async def __call__(self, model_id: str, array: np.ndarray):
+        model = await self.get_model(model_id)
+        return model.encode(array)

--- a/bioimageio_colab/models/sam_image_encoder.py
+++ b/bioimageio_colab/models/sam_image_encoder.py
@@ -1,55 +1,25 @@
-import os
-from functools import partial
 from typing import Literal
 
 import numpy as np
-import requests
 import torch
-from ray import serve
 from segment_anything import sam_model_registry
 from segment_anything.utils.transforms import ResizeLongestSide
 
 
-@serve.deployment(
-    num_replicas=1,
-    max_ongoing_requests=1,
-    ray_actor_options={"num_gpus": 1},
-)
 class SamImageEncoder:
     def __init__(
-        self,
-        cache_dir: str,
-        model_name: str,
-        model_url: str,
-        model_architecture: Literal["vit_b", "vit_l", "vit_h"],
+        self, model_path: str, model_architecture: Literal["vit_b", "vit_l", "vit_h"]
     ):
-        model_path = os.path.join(cache_dir, f"{model_name}.pt")
-
-        # Download model if not available
-        if not os.path.exists(model_path):
-            self._download_model(
-                model_path=model_path,
-                model_url=model_url,
-            )
-
         # Extract image encoder from checkpoint
-        sam = self._load_model(model_path, model_architecture)
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        build_sam = sam_model_registry[model_architecture]
+        sam = build_sam(checkpoint=model_path).to(device)
         self.image_encoder = sam.image_encoder
-        self.image_encoder
         self.device = sam.device
 
-        # Define image transform and preprocess
-        self.transform = ResizeLongestSide(sam.image_encoder.img_size)
-        self.preprocess = sam.preprocess
-
-    def _download_model(self, model_path: str, model_url: str) -> None:
-        cache_dir = os.path.dirname(model_path)
-        os.makedirs(cache_dir, exist_ok=True)
-        response = requests.get(model_url)
-        if response.status_code != 200:
-            raise RuntimeError(f"Failed to download model from {model_url}")
-        with open(model_path, "wb") as f:
-            f.write(response.content)
+        # Define image transform and normalization
+        self._transform = ResizeLongestSide(sam.image_encoder.img_size)
+        self._normalize_and_pad = sam.preprocess
 
     def _to_image_format(self, array: np.ndarray) -> np.ndarray:
         # Convert input to np.ndarray
@@ -83,17 +53,11 @@ class SamImageEncoder:
 
         return array
 
-    def _load_model(self, model_path: str, model_architecture: str) -> torch.nn.Module:
-        device = "cuda" if torch.cuda.is_available() else "cpu"
-        sam = sam_model_registry[model_architecture](checkpoint=model_path)
-        return sam.to(device)
-
-    def __call__(self, array: np.ndarray):
-        """image in RGB format (np.ndarray with shape (H, W, 3) and dtype uint8)"""
+    def _preprocess(self, array: np.array) -> torch.Tensor:
         # Validate image shape and dtype
         original_image = self._to_image_format(array)
 
-        input_image = self.transform.apply_image(original_image)  # input: np.array
+        input_image = self._transform.apply_image(original_image)  # input: np.array
 
         input_image_torch = torch.as_tensor(input_image, device=self.device)
 
@@ -109,53 +73,45 @@ class SamImageEncoder:
         ), f"set_torch_image input must be BCHW with long side {self.image_encoder.img_size}."
 
         # Preprocess the image before feeding it to the model
-        input_image_torch = self.preprocess(input_image_torch)
-        input_size = tuple(input_image_torch.shape[-2:])
+        input_image_torch = self._normalize_and_pad(input_image_torch)
+
+        return input_image_torch
+
+    def encode(self, array: np.ndarray):
+        """
+        Encode an image using the SAM image encoder.
+
+        Args:
+            array (np.ndarray): Input image in either 2-channel grayscale (H, W) or 3-channel RGB (H, W, 3) format.
+
+        Returns:
+            dict: A dictionary containing the following keys:
+                - "features" (np.ndarray): The extracted features from the image
+                - "input_size" (tuple): The size of the input image (H, W)
+        """
+        # Preprocess the input image
+        input_image = self._preprocess(array)
+        input_size = tuple(input_image.shape[-2:])
 
         # Run inference
         with torch.no_grad():
-            features = self.image_encoder(input_image_torch)
+            features = self.image_encoder(input_image)
 
         return {"features": features.cpu().numpy(), "input_size": input_size}
 
 
-model_urls = {
-    "sam_vit_b": "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_b_01ec64.pth",
-    "sam_vit_b_lm": "https://uk1s3.embassy.ebi.ac.uk/public-datasets/bioimage.io/diplomatic-bug/1/files/vit_b.pt",
-    "sam_vit_b_em_organelles": "https://uk1s3.embassy.ebi.ac.uk/public-datasets/bioimage.io/noisy-ox/1/files/vit_b.pt",
-}
-
-sam_app_registry = {
-    model_name: partial(
-        SamImageEncoder.options(name=model_name).bind,
-        model_name=model_name,
-        model_url=model_urls[model_name],
-        model_architecture=model_architecture,
-    )
-    for model_name, model_architecture in [
-        ("sam_vit_b", "vit_b"),
-        ("sam_vit_b_lm", "vit_b"),
-        ("sam_vit_b_em_organelles", "vit_b"),
-    ]
-}
-
-
 if __name__ == "__main__":
-    #! Comment out lines 13-17 and 128-140 to test this class without Ray Serve
     from tifffile import imread
 
     # Deploy the model
-    model_name = "sam_vit_b"
-    cache_dir = "./.model_cache"
-
-    deployment = SamImageEncoder(
-        cache_dir=cache_dir,
-        model_name=model_name,
-        model_url=model_urls[model_name],
+    model = SamImageEncoder(
+        model_path="./.model_cache/sam_vit_b.pt",
         model_architecture="vit_b",
     )
 
-    image = imread("./bioimageio_colab/example_image.tif")
+    image_array = imread("./data/example_image.tif")
 
-    result = deployment(image)
-    print(result)
+    result = model.encode(image_array)
+    print(result.keys())
+    print(result["features"].shape)
+    print(result["input_size"])


### PR DESCRIPTION
These improvements have been made to the Ray Serve deployment of the SAM image encoder

* Using [Model Multiplexing](https://docs.ray.io/en/latest/serve/model-multiplexing.html) with the following models:
   * `sam_vit_b`
   * `sam_vit_b_lm`
   * `sam_vit_b_em_organelles`
* Added test runs for each model
* Added [AutoscalingConfig](https://docs.ray.io/en/latest/serve/api/doc/ray.serve.config.AutoscalingConfig.html#ray.serve.config.AutoscalingConfig)
* Improved `readiness` and `liveness` probes that include the status of the hypha service and Ray Serve deployment
